### PR TITLE
typo at lines 6 and 13

### DIFF
--- a/helm/perf-utils/templates/perfutils-pod.yaml
+++ b/helm/perf-utils/templates/perfutils-pod.yaml
@@ -3,14 +3,14 @@ kind: Pod
 metadata:
   annotations:
     openshift.io/scc: privileged
-  name: name: {{ regexReplaceAll "\\W+" .Values.nodeName "-" }}-perfutils
+  name: {{ regexReplaceAll "\\W+" .Values.nodeName "-" }}-perfutils
 spec:
   containers:
   - command:
     - /bin/bash
     image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
     imagePullPolicy: {{ .Values.image.pullPolicy }}
-    name: name: {{ regexReplaceAll "\\W+" .Values.nodeName "-" }}-perfutils
+    name: {{ regexReplaceAll "\\W+" .Values.nodeName "-" }}-perfutils
     resources: {}
     securityContext:
       privileged: true


### PR DESCRIPTION
a typo at lines 6 and 13 with "name:" repetition that fired up this errore while installing:

[mplacidi@mplacidi perf-utils]$ helm install ./helm/perf-utils --set nodeName=master-0 --generate-name Error: INSTALLATION FAILED: YAML parse error on perf-utils/templates/perfutils-pod.yaml: error converting YAML to JSON: yaml: line 6: mapping values are not allowed in this context (fix at line 6 and then the following error pops-up) [mplacidi@mplacidi perf-utils]$ helm install ./helm/perf-utils --set nodeName=master-0 --generate-name Error: INSTALLATION FAILED: YAML parse error on perf-utils/templates/perfutils-pod.yaml: error converting YAML to JSON: yaml: line 13: mapping values are not allowed in this context